### PR TITLE
Update uk.md

### DIFF
--- a/uk.md
+++ b/uk.md
@@ -29,8 +29,7 @@ process to reassign your sex) in the Equality Act.
 UK bans some trans care, notably most use of puberty blockers for anyone
 under the age of 18 when used for gender transition. This ban also
 applies to out-of-country prescription. It may impact UK citizens
-bringing puberty blockers into the country. Note that this ban does not
-apply in Northern Ireland.
+bringing puberty blockers into the country.
 
 ## Non-discrimination Law
 
@@ -113,11 +112,10 @@ Non-binary gender is not recognized in the UK.
 
  * Trans medical care is legal for adults.
  * A [UK
-   law](https://www.legislation.gov.uk/uksi/2024/727/pdfs/uksi_20240727_en.pdf)
+   law](https://www.legislation.gov.uk/uksi/2024/868/pdfs/uksi_20240868_en.pdf)
    bans transition-related puberty blockers in most cases for people under 18.
-   This law applies within the UK, except for Northern Ireland. This may
-   impact UK citizens bringing puberty blockers from overseas, even with
-   a valid overseas prescription. Overseas prescribers will not be able
+   This may impact UK citizens bringing puberty blockers from overseas, even
+   with a valid overseas prescription. Overseas prescribers will not be able
    to issue prescriptions to be filled in the UK.
  * Trans patients will be ineligible to be treated on single-sex wards
    that don't match their "biological sex" (AKA sex assigned at birth)


### PR DESCRIPTION
Since August 27th, the UK puberty blocker ban also applies to Northern Ireland ([source](https://www.health-ni.gov.uk/news/temporary-ban-prescription-and-supply-puberty-blockers-extended-ni)).

This PR:
- removes any mentions of the ban not applying to Northern Ireland
- replaces the link to the old emergency order with a link to the new extension order currently in effect